### PR TITLE
For concept review only: Failover from SeqSink to DurableSeqSink when exception thrown

### DIFF
--- a/src/Serilog.Sinks.Seq/FailoverSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/FailoverSeqSink.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.Seq;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Sink uses non-durable for log entries.  If exception is thrown from Emit(), then LogEntry is sent to durable log shipper.
+    /// </summary>
+    class FailoverSeqSink : SeqSink, IDisposable
+    {
+        private readonly Lazy<DurableSeqSink> _durableSink; 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="serverUrl"></param>
+        /// <param name="bufferBaseFilename"></param>
+        /// <param name="apiKey"></param>
+        /// <param name="batchPostingLimit"></param>
+        /// <param name="batchPeriod"></param>
+        /// <param name="durableShipperPeriod"></param>
+        /// <param name="bufferFileSizeLimitBytes"></param>
+        public FailoverSeqSink(string serverUrl, string bufferBaseFilename, string apiKey, int batchPostingLimit, TimeSpan batchPeriod, TimeSpan durableShipperPeriod, long? bufferFileSizeLimitBytes)
+            :base(serverUrl, apiKey, batchPostingLimit, batchPeriod)
+        {
+            _durableSink = new Lazy<DurableSeqSink>(() => new DurableSeqSink(serverUrl, bufferBaseFilename, apiKey, batchPostingLimit, durableShipperPeriod, bufferFileSizeLimitBytes));
+        }
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing && _durableSink.IsValueCreated)
+            {
+                _durableSink.Value.Dispose();
+            }
+        }
+
+        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        {
+            try
+            {
+                await base.EmitBatchAsync(events);
+            }
+            catch (Exception)
+            {
+                EmitToDurableSink(events);
+            }
+        }
+
+        private void EmitToDurableSink(IEnumerable<LogEvent> events)
+        {
+            foreach (var logEvent in events)
+            {
+                _durableSink.Value.Emit(logEvent);
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -42,7 +42,7 @@ namespace Serilog
         /// log file for a specific date will be allowed to grow. By default no limit will be applied.</param>
         /// <param name="failOverToDurable">True to failover to durable log shipper only when non-durable log shipping fails</param>
         /// <param name="failoverRestrictedToMinimumLevel">Min level to send to failover.  Ex: Send Debug to non-durable, but only failover Error and higher to durable</param>
-        /// <param name="failOverDurablePeriod"></param>
+        /// <param name="failOverDurablePeriod">Batching period for durable sink used for failover.  Null defaults to same as period.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Seq(
@@ -63,7 +63,7 @@ namespace Serilog
             if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
 
             var defaultedPeriod = period ?? SeqSink.DefaultPeriod;
-            var failoverPeriod = failOverDurablePeriod ?? SeqSink.DefaultPeriod;
+            var failoverPeriod = failOverDurablePeriod ?? defaultedPeriod;
 
             ILogEventSink sink;
             if (failOverToDurable)

--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -40,6 +40,9 @@ namespace Serilog
         /// <param name="apiKey">A Seq <i>API key</i> that authenticates the client to the Seq server.</param>
         /// <param name="bufferFileSizeLimitBytes">The maximum size, in bytes, to which the buffer
         /// log file for a specific date will be allowed to grow. By default no limit will be applied.</param>
+        /// <param name="failOverToDurable">True to failover to durable log shipper only when non-durable log shipping fails</param>
+        /// <param name="failoverRestrictedToMinimumLevel">Min level to send to failover.  Ex: Send Debug to non-durable, but only failover Error and higher to durable</param>
+        /// <param name="failOverDurablePeriod"></param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Seq(
@@ -50,19 +53,45 @@ namespace Serilog
             TimeSpan? period = null,
             string apiKey = null,
             string bufferBaseFilename = null,
-            long? bufferFileSizeLimitBytes = null)
+            long? bufferFileSizeLimitBytes = null,
+            bool failOverToDurable = false,
+            LogEventLevel failoverRestrictedToMinimumLevel = LevelAlias.Minimum,
+            TimeSpan? failOverDurablePeriod = null)
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException("loggerSinkConfiguration");
             if (serverUrl == null) throw new ArgumentNullException("serverUrl");
             if (bufferFileSizeLimitBytes.HasValue && bufferFileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
 
             var defaultedPeriod = period ?? SeqSink.DefaultPeriod;
+            var failoverPeriod = failOverDurablePeriod ?? SeqSink.DefaultPeriod;
 
             ILogEventSink sink;
-            if (bufferBaseFilename == null)
+            if (failOverToDurable)
+            {
+                sink = new FailoverSeqSink(
+                    serverUrl,
+                    bufferBaseFilename,
+                    apiKey,
+                    batchPostingLimit,
+                    defaultedPeriod,
+                    bufferFileSizeLimitBytes,
+                    failoverPeriod,
+                    failoverRestrictedToMinimumLevel);
+            }
+            else if (bufferBaseFilename == null)
+            {
                 sink = new SeqSink(serverUrl, apiKey, batchPostingLimit, defaultedPeriod);
+            }
             else
-                sink = new DurableSeqSink(serverUrl, bufferBaseFilename, apiKey, batchPostingLimit, defaultedPeriod, bufferFileSizeLimitBytes);
+            {
+                sink = new DurableSeqSink(
+                    serverUrl,
+                    bufferBaseFilename,
+                    apiKey,
+                    batchPostingLimit,
+                    defaultedPeriod,
+                    bufferFileSizeLimitBytes);
+            }
 
             return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -57,6 +57,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FailoverSeqSink.cs" />
     <Compile Include="Sinks\Seq\DurableSeqSink.cs" />
     <Compile Include="Sinks\Seq\HttpLogShipper.cs" />
     <Compile Include="Sinks\Seq\SeqApi.cs" />

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -57,7 +57,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="FailoverSeqSink.cs" />
+    <Compile Include="Sinks\Seq\FailoverSeqSink.cs" />
     <Compile Include="Sinks\Seq\DurableSeqSink.cs" />
     <Compile Include="Sinks\Seq\HttpLogShipper.cs" />
     <Compile Include="Sinks\Seq\SeqApi.cs" />

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/FailoverSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/FailoverSeqSink.cs
@@ -2,29 +2,15 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-using Serilog.Core;
 using Serilog.Events;
-using Serilog.Sinks.Seq;
 
-namespace Serilog
+namespace Serilog.Sinks.Seq
 {
-    /// <summary>
-    /// Sink uses non-durable for log entries.  If exception is thrown from Emit(), then LogEntry is sent to durable log shipper.
-    /// </summary>
-    class FailoverSeqSink : SeqSink, IDisposable
+    class FailoverSeqSink : SeqSink
     {
-        private readonly Lazy<DurableSeqSink> _durableSink; 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="serverUrl"></param>
-        /// <param name="bufferBaseFilename"></param>
-        /// <param name="apiKey"></param>
-        /// <param name="batchPostingLimit"></param>
-        /// <param name="batchPeriod"></param>
-        /// <param name="durableShipperPeriod"></param>
-        /// <param name="bufferFileSizeLimitBytes"></param>
-        public FailoverSeqSink(string serverUrl, string bufferBaseFilename, string apiKey, int batchPostingLimit, TimeSpan batchPeriod, TimeSpan durableShipperPeriod, long? bufferFileSizeLimitBytes)
+        private readonly Lazy<DurableSeqSink> _durableSink;
+
+        public FailoverSeqSink(string serverUrl, string bufferBaseFilename, string apiKey, int batchPostingLimit, TimeSpan batchPeriod, long? bufferFileSizeLimitBytes, TimeSpan durableShipperPeriod, LogEventLevel failoverRestrictedToMinimumLevel)
             :base(serverUrl, apiKey, batchPostingLimit, batchPeriod)
         {
             _durableSink = new Lazy<DurableSeqSink>(() => new DurableSeqSink(serverUrl, bufferBaseFilename, apiKey, batchPostingLimit, durableShipperPeriod, bufferFileSizeLimitBytes));


### PR DESCRIPTION
@nblumhardt,
This is super early stages, AKA not tested at all, but what do you think about having a failover sink in serilog/serilog-sinks-seq or is this more of something I would keep off to the side and maintain myself?  Is this conceptually sound, or can you see places I am going to get into trouble?

References:
http://stackoverflow.com/a/33539002
#10
